### PR TITLE
Modified hammer recipe

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -368,6 +368,6 @@ minetest.register_craft({
 	recipe = {
                 {"default:steel_ingot","default:steel_ingot","default:steel_ingot"},
                 {"default:steel_ingot","default:steel_ingot","default:steel_ingot"},
-                {'',                   "group:stick",      ''                   } }
+                {"group:stick",        '',                   ''                   } }
 })
 


### PR DESCRIPTION
The default recipe conflicts with Minetest Game's steel sign, thus steel signs can't be crafted.