### PR TITLE
add ownercheck to anvil

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -375,6 +375,6 @@ minetest.register_craft({
 	recipe = {
                 {"default:steel_ingot","default:steel_ingot","default:steel_ingot"},
                 {"default:steel_ingot","default:steel_ingot","default:steel_ingot"},
-                {'',                   "group:stick",      ''                   } }
+                {"group:stick","",""}} }
 })
 

--- a/init.lua
+++ b/init.lua
@@ -147,7 +147,10 @@ minetest.register_node("anvil:anvil", {
 	can_dig = function(pos,player)
 		local meta  = minetest.get_meta(pos)
 		local inv   = meta:get_inventory()
-	
+		--[[
+		if player:get_player_name() ~= meta:get_string("owner") then
+			return false
+	]]
 		if not inv:is_empty("input") then
 			return false
 		end
@@ -183,25 +186,29 @@ minetest.register_node("anvil:anvil", {
 	end,
 	
 	on_rightclick = function(pos, node, clicker, itemstack)
-		if itemstack:get_count() == 0 then
-			local meta = minetest.get_meta(pos)
-			local inv = meta:get_inventory()
-			if not inv:is_empty("input") then
-				local return_stack = inv:get_stack("input", 1)
-				inv:set_stack("input", 1, nil)
-				local wield_index = clicker:get_wield_index()
-				clicker:get_inventory():set_stack("main", wield_index, return_stack)
-				remove_item(pos, node)
-				return return_stack
-			end		
-		end
-		local this_def = minetest.registered_nodes[node.name]
-		if this_def.allow_metadata_inventory_put(pos, "input", 1, itemstack:peek_item(), clicker) > 0 then
-			local s = itemstack:take_item()
-			local meta = minetest.get_meta(pos)
-			local inv = meta:get_inventory()
-			inv:add_item("input", s)
-			update_item(pos,node)
+		local meta = minetest.get_meta(pos)
+		local name = clicker:get_player_name()
+		--minetest.chat_send_player(name,">>> owner is :"..dump(meta:get_string("owner")).." used by : "..name)
+		if name == meta:get_string("owner") then
+		      if itemstack:get_count() == 0 then
+			      local inv = meta:get_inventory()
+			      if not inv:is_empty("input") then
+				      local return_stack = inv:get_stack("input", 1)
+				      inv:set_stack("input", 1, nil)
+				      local wield_index = clicker:get_wield_index()
+				      clicker:get_inventory():set_stack("main", wield_index, return_stack)
+				      remove_item(pos, node)
+				      return return_stack
+			      end		
+		      end
+		      local this_def = minetest.registered_nodes[node.name]
+		      if this_def.allow_metadata_inventory_put(pos, "input", 1, itemstack:peek_item(), clicker) > 0 then
+			      local s = itemstack:take_item()
+			      local meta = minetest.get_meta(pos)
+			      local inv = meta:get_inventory()
+			      inv:add_item("input", s)
+			      update_item(pos,node)
+		      end
 		end
 		return itemstack
 	end,
@@ -368,6 +375,6 @@ minetest.register_craft({
 	recipe = {
                 {"default:steel_ingot","default:steel_ingot","default:steel_ingot"},
                 {"default:steel_ingot","default:steel_ingot","default:steel_ingot"},
-                {"group:stick", '', ''} },
+                {'',                   "group:stick",      ''                   } }
 })
 

--- a/init.lua
+++ b/init.lua
@@ -375,6 +375,6 @@ minetest.register_craft({
 	recipe = {
                 {"default:steel_ingot","default:steel_ingot","default:steel_ingot"},
                 {"default:steel_ingot","default:steel_ingot","default:steel_ingot"},
-                {"group:stick","",""}} }
+                {"group:stick","",""} }
 })
 


### PR DESCRIPTION
Now your tools are safe on the anvil.
Only the owner can put/take on/from anvil

Owner was already in metadata, it was just not checked for it.
