### PR TITLE
Add nil check for clicker and item stack

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -215,6 +215,9 @@ minetest.register_node("anvil:anvil", {
 	end,
 
 	on_rightclick = function(pos, node, clicker, itemstack)
+		if not clicker or not itemstack then
+			return
+		end
 		local meta = minetest.get_meta(pos)
 		local name = clicker:get_player_name()
 


### PR DESCRIPTION
This prevents crashes when on_rightclick is called by a mod.