### PR TITLE
Fix crash when removing HUD's

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -317,7 +317,7 @@ minetest.register_node("anvil:anvil", {
 			})
 		end
 		minetest.after(2, function()
-		if( puncher ) then
+		if( puncher ) and ( hud2 ) and ( hud3 ) then
 			puncher:hud_remove(hud2)
 			puncher:hud_remove(hud3)
 			end


### PR DESCRIPTION
Fixes a crash when removing HUD's.
Tested on MT `5.4.0-c940a57a3-c940a57a3-dirty`.
```
2020-11-13 14:23:57: ERROR[Main]: ServerError: AsyncErr: environment_Step: Runtime error from mod 'anvil' in callback environment_Step(): ...\Desktop\minetest-5.4.0-win64\bin\..\mods\anvil\init.lua:321: bad argument #1 to 'hud_remove' (number expected, got nil)
2020-11-13 14:23:57: ERROR[Main]: stack traceback:
2020-11-13 14:23:57: ERROR[Main]: 	[C]: in function 'hud_remove'
2020-11-13 14:23:57: ERROR[Main]: 	...\Desktop\minetest-5.4.0-win64\bin\..\mods\anvil\init.lua:321: in function 'func'
2020-11-13 14:23:57: ERROR[Main]: 	...top\minetest-5.4.0-win64\bin\..\builtin\common\after.lua:20: in function <...top\minetest-5.4.0-win64\bin\..\builtin\common\after.lua:5>
2020-11-13 14:23:57: ERROR[Main]: 	...op\minetest-5.4.0-win64\bin\..\builtin\game\register.lua:435: in function <...op\minetest-5.4.0-win64\bin\..\builtin\game\register.lua:419>
```
