### PR TITLE
Protect anvil's `input` inventory from take/put if player is not the owner

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -150,6 +150,18 @@ local update_item = function(pos, node)
 	end
 end
 
+local function has_access(pos, player)
+	local name = player:get_player_name()
+	local meta = minetest.get_meta(pos)
+	local owner = meta:get_string("owner")
+	local shared = meta:get_int("shared") == 1
+	if shared or name == owner then
+		return true
+	else
+		return false
+	end
+end
+
 local metal_sounds
 -- Apparently node_sound_metal_defaults is a newer thing, I ran into games using an older version of the default mod without it.
 if default.node_sound_metal_defaults ~= nil then
@@ -257,11 +269,11 @@ minetest.register_node("anvil:anvil", {
 			return 0
 		end
 
-		local player_name = player:get_player_name()
-		local owner = meta:get_string("owner")
-		if owner ~= player_name then
+		if not has_access(pos, player) then
 			return 0
 		end
+
+		local player_name = player:get_player_name()
 		if stack:get_wear() == 0 then
 			minetest.chat_send_player(player_name, S("This anvil is for damaged tools only."))
 			return 0
@@ -281,12 +293,10 @@ minetest.register_node("anvil:anvil", {
 	end,
 
 	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
-		local meta = minetest.get_meta(pos)
-		local player_name = player:get_player_name()
-		local owner = meta:get_string("owner")
-		if owner ~= player_name then
+		if not has_access(pos, player) then
 			return 0
 		end
+
 		if listname ~= "input" then
 			return 0
 		end

--- a/init.lua
+++ b/init.lua
@@ -258,6 +258,10 @@ minetest.register_node("anvil:anvil", {
 		end
 
 		local player_name = player:get_player_name()
+		local owner = meta:get_string("owner")
+		if owner ~= player_name then
+			return 0
+		end
 		if stack:get_wear() == 0 then
 			minetest.chat_send_player(player_name, S("This anvil is for damaged tools only."))
 			return 0
@@ -277,6 +281,12 @@ minetest.register_node("anvil:anvil", {
 	end,
 
 	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
+		local meta = minetest.get_meta(pos)
+		local player_name = player:get_player_name()
+		local owner = meta:get_string("owner")
+		if owner ~= player_name then
+			return 0
+		end
 		if listname ~= "input" then
 			return 0
 		end


### PR DESCRIPTION
This PR fixes vulnerability that can be used for stealing tools of other players' anvils. In other words, any player could take/put damaged tools on any anvil using a [special clientside mod](https://github.com/zmv7/minetest-csm-anvilhack).
### How to test
* Place the anvil in the singleplayer world and put any tool on it.
* Rejoin the same world with different nickname(check "Host Server" in the menu and specify nickname).
* Try to take the previously placed tool using the the above clientside mod.
* Apply the patch from this PR and repeat above steps