### PR TITLE
Allow other screwdrivers to get repaired too

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -253,6 +253,7 @@ local function anvil_rotate(pos, node, user, mode, new_param2)
 	local player_name = user:get_player_name()
 	local wield_list = user:get_wield_list()
 	local wield_index = user:get_wield_index()
+	local wielded_original = user:get_inventory():get_stack(wield_list, wield_index)
 
 	minetest.after(0,function()
 		local player = minetest.get_player_by_name(player_name)
@@ -262,6 +263,10 @@ local function anvil_rotate(pos, node, user, mode, new_param2)
 
 		local inv = player:get_inventory()
 		local wielded = inv:get_stack(wield_list, wield_index)
+
+		if wielded:get_name() ~= wielded_original:get_name() then
+			return
+		end
 
 		local node_now = minetest.get_node(pos)
 		if node_now.name ~= "anvil:anvil" then

--- a/init.lua
+++ b/init.lua
@@ -263,10 +263,6 @@ local function anvil_rotate(pos, node, user, mode, new_param2)
 		local inv = player:get_inventory()
 		local wielded = inv:get_stack(wield_list, wield_index)
 
-		if wielded:get_name() ~= "screwdriver:screwdriver" then
-			return
-		end
-
 		local node_now = minetest.get_node(pos)
 		if node_now.name ~= "anvil:anvil" then
 			return


### PR DESCRIPTION
This change will allow other screwdrivers which use the `screwdriver.ROTATE_AXIS` mode to get repaired in the anvil. I couldn't find something that gets broken by this.